### PR TITLE
fix(): add 'config' as possible diagnostic type

### DIFF
--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -17,7 +17,7 @@ export interface PluginCtx {
 
 export interface Diagnostic {
   level: 'error' | 'warn' | 'info' | 'log' | 'debug';
-  type: 'typescript' | 'bundling' | 'build' | 'runtime' | 'hydrate' | 'css';
+  type: 'typescript' | 'bundling' | 'build' | 'runtime' | 'hydrate' | 'css' | 'config';
   header?: string;
   language?: string;
   messageText: string;


### PR DESCRIPTION
This fixes a type clash when using it with Stencil One.

```ts
import { stylus } from '@stencil/stylus';

export const config: Config = {
  plugins: [stylus()]
};
```

otherwise produces this error:

```
Type '{ name: string; transform(sourceText: string, fileName: string, context: PluginCtx): Promise<PluginTransformResults>; }' is not assignable to type 'Plugin'.
  Types of property 'transform' are incompatible.
    Type '(sourceText: string, fileName: string, context: PluginCtx) => Promise<PluginTransformResults>' is not assignable to type '(sourceText: string, id: string, context: PluginCtx) => string | PluginTransformResults | Promise<PluginTransformResults>'.
      Types of parameters 'context' and 'context' are incompatible.
        Type 'import("/Users/simonhaenisch/Work/jitbug/pwa/node_modules/@stencil/core/dist/declarations/plugin").PluginCtx' is not assignable to type 'import("/Users/simonhaenisch/Work/jitbug/pwa/node_modules/@stencil/stylus/dist/declarations").PluginCtx'.
          Types of property 'diagnostics' are incompatible.
            Type 'import("/Users/simonhaenisch/Work/jitbug/pwa/node_modules/@stencil/core/dist/declarations/diagnostics").Diagnostic[]' is not assignable to type 'import("/Users/simonhaenisch/Work/jitbug/pwa/node_modules/@stencil/stylus/dist/declarations").Diagnostic[]'.
              Type 'import("/Users/simonhaenisch/Work/jitbug/pwa/node_modules/@stencil/core/dist/declarations/diagnostics").Diagnostic' is not assignable to type 'import("/Users/simonhaenisch/Work/jitbug/pwa/node_modules/@stencil/stylus/dist/declarations").Diagnostic'.
                Types of property 'type' are incompatible.
                  Type '"typescript" | "bundling" | "build" | "runtime" | "hydrate" | "css" | "config"' is not assignable to type '"typescript" | "bundling" | "build" | "runtime" | "hydrate" | "css"'.
                    Type '"config"' is not assignable to type '"typescript" | "bundling" | "build" | "runtime" | "hydrate" | "css"'.
```