### PR TITLE
chore: update stylus

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test.watch": "jest --watch"
   },
   "dependencies": {
-    "stylus": "0.54.5"
+    "stylus": "0.54.8"
   },
   "peerDependencies": {
     "@stencil/core": "^1.0.2"


### PR DESCRIPTION
Because there's annoying console logs with Node 14 that have been fixed. See https://github.com/stylus/stylus/issues/2534.